### PR TITLE
Infer entry point from "load"

### DIFF
--- a/packages/plugin/src/context.ts
+++ b/packages/plugin/src/context.ts
@@ -12,12 +12,12 @@ export function createContext(options: Options): Context{
     const { include, exclude } = formatedOptions
     const filter = createFilter(include, exclude)
 
-    const { getRootModuleId, setRootModuleId, moduleIdNodeMap } = initModule()
+    const { getRootModuleNode, handleLoadModule, moduleIdNodeMap } = initModule()
     return {
         ...formatedOptions,
         filter,
-        getRootModuleId,
-        setRootModuleId,
+        getRootModuleNode,
+        handleLoadModule,
         moduleIdNodeMap
     }
 }
@@ -56,8 +56,8 @@ function initModule(){
     const { getRootModuleId, setRootModuleId } = initRootModuleId()
     const moduleIdNodeMap = new Map<string, ModuleNode>()
     return {
-        getRootModuleId,
-        setRootModuleId,
+        getRootModuleNode: () => moduleIdNodeMap.get(getRootModuleId()),
+        handleLoadModule: setRootModuleId,
         moduleIdNodeMap
     }
 }

--- a/packages/plugin/src/context.ts
+++ b/packages/plugin/src/context.ts
@@ -2,7 +2,7 @@ import type { Options, Context, CircleData } from "./types";
 import type { ModuleNode } from './module/moduleNode'
 
 import { createFilter } from '@rollup/pluginutils'
-import { initRootModuleNode } from './util'
+import { initRootModuleId } from './util'
 import { join } from 'node:path'
 import { relative } from 'node:path'
 
@@ -12,12 +12,12 @@ export function createContext(options: Options): Context{
     const { include, exclude } = formatedOptions
     const filter = createFilter(include, exclude)
 
-    const { getRootModuleNode, setRootModuleNode, moduleIdNodeMap } = initModule()
+    const { getRootModuleId, setRootModuleId, moduleIdNodeMap } = initModule()
     return {
         ...formatedOptions,
         filter,
-        getRootModuleNode,
-        setRootModuleNode,
+        getRootModuleId,
+        setRootModuleId,
         moduleIdNodeMap
     }
 }
@@ -53,11 +53,11 @@ function defaultFormatOut(data: CircleData){
 }
 
 function initModule(){
-    const { getRootModuleNode, setRootModuleNode } = initRootModuleNode()
+    const { getRootModuleId, setRootModuleId } = initRootModuleId()
     const moduleIdNodeMap = new Map<string, ModuleNode>()
     return {
-        getRootModuleNode,
-        setRootModuleNode,
+        getRootModuleId,
+        setRootModuleId,
         moduleIdNodeMap
     }
 }

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -12,8 +12,8 @@ export default (options: Options) => {
     const ctx = createContext(options)
     const { 
         filter,
-        getRootModuleId,
-        setRootModuleId,
+        getRootModuleNode,
+        handleLoadModule,
         moduleIdNodeMap
      } = ctx
     return {
@@ -23,7 +23,7 @@ export default (options: Options) => {
                 return
             }
 
-            setRootModuleId(id)
+            handleLoadModule(id)
         },
         moduleParsed: (moduleInfo: ModuleInfo) => {
             const { id } = moduleInfo
@@ -34,8 +34,7 @@ export default (options: Options) => {
             moduleIdNodeMap.set(moduleInfo.id, moduleNode)
         },
         generateBundle(){
-            const rootModuleId = getRootModuleId()
-            const rootModuleNode = moduleIdNodeMap.get(rootModuleId)
+            const rootModuleNode = getRootModuleNode()
             if(!rootModuleNode){
                 console.error('Failed to generate entry module');
                 return

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -12,23 +12,30 @@ export default (options: Options) => {
     const ctx = createContext(options)
     const { 
         filter,
-        getRootModuleNode,
-        setRootModuleNode,
+        getRootModuleId,
+        setRootModuleId,
         moduleIdNodeMap
      } = ctx
     return {
         name: 'vite-plugin-circular-dependency',
+        load: (id: string) => {
+            if(!filter(id)){
+                return
+            }
+
+            setRootModuleId(id)
+        },
         moduleParsed: (moduleInfo: ModuleInfo) => {
             const { id } = moduleInfo
             if(!filter(id)){
                 return
             }
             const moduleNode = generateModuleNode(moduleInfo)
-            setRootModuleNode(moduleNode)
             moduleIdNodeMap.set(moduleInfo.id, moduleNode)
         },
         generateBundle(){
-            const rootModuleNode = getRootModuleNode()
+            const rootModuleId = getRootModuleId()
+            const rootModuleNode = moduleIdNodeMap.get(rootModuleId)
             if(!rootModuleNode){
                 console.error('Failed to generate entry module');
                 return

--- a/packages/plugin/src/types/context.ts
+++ b/packages/plugin/src/types/context.ts
@@ -4,7 +4,8 @@ import type { Options } from './options'
 
 export type Context = {
     filter: (id: string) => boolean,
+    getRootModuleNode: () => ModuleNode | undefined
+    handleLoadModule: (moduleId: string) => void
     moduleIdNodeMap: Map<string, ModuleNode>
 } 
-& ReturnType<typeof initRootModuleId> 
 & Required<Options>

--- a/packages/plugin/src/types/context.ts
+++ b/packages/plugin/src/types/context.ts
@@ -1,10 +1,10 @@
 import type { ModuleNode } from '../module/moduleNode'
-import type { initRootModuleNode } from '../util'
+import type { initRootModuleId } from '../util'
 import type { Options } from './options'
 
 export type Context = {
     filter: (id: string) => boolean,
     moduleIdNodeMap: Map<string, ModuleNode>
 } 
-& ReturnType<typeof initRootModuleNode> 
+& ReturnType<typeof initRootModuleId> 
 & Required<Options>

--- a/packages/plugin/src/util/moduleNode.ts
+++ b/packages/plugin/src/util/moduleNode.ts
@@ -4,6 +4,7 @@ export type ModuleInfo = {
     id: string;
     importedIds: string[];
     dynamicallyImportedIds: string[]
+    importers: any;
 }
 
 /** 获取模块所有引用的 模块id */
@@ -19,15 +20,15 @@ export function generateModuleNode(moduleInfo: ModuleInfo){
     return new ModuleNode(id, importerModuleIds)
 }
 
-export function initRootModuleNode(){
-    let rootModuleNode: ModuleNode | null
+export function initRootModuleId(){
+    let rootModuleId: string
     return {
-        getRootModuleNode(){
-            return rootModuleNode
+        getRootModuleId(){
+            return rootModuleId
         },
-        setRootModuleNode(moduleNode: ModuleNode){
-            if(!rootModuleNode){
-                rootModuleNode = moduleNode
+        setRootModuleId(moduleId: string){
+            if(!rootModuleId){
+                rootModuleId = moduleId
             }
         }
     }

--- a/packages/plugin/src/util/moduleNode.ts
+++ b/packages/plugin/src/util/moduleNode.ts
@@ -4,7 +4,6 @@ export type ModuleInfo = {
     id: string;
     importedIds: string[];
     dynamicallyImportedIds: string[]
-    importers: any;
 }
 
 /** 获取模块所有引用的 模块id */


### PR DESCRIPTION
The current version tries to infer the entry point or "root module" by the first module passed through `moduleParsed` however that's not actually necessarily the root. In my case I had ~10 different modules passed through that function before my entry point file.

This PR instead infers the entry point by the first module id passed through the `load` function. This can actually be guaranteed to be the root.